### PR TITLE
Apply maintenance fixes

### DIFF
--- a/ApplicationLibrary/Views/Groups/GroupListView.swift
+++ b/ApplicationLibrary/Views/Groups/GroupListView.swift
@@ -16,7 +16,7 @@ public struct GroupListView: View {
             } else if !groups.isEmpty {
                 ScrollView {
                     VStack {
-                        ForEach(groups, id: \.hashValue) { it in
+                        ForEach(groups, id: \.tag) { it in
                             GroupView(it)
                         }
                     }.padding()

--- a/MacLibrary/MenuLabel.swift
+++ b/MacLibrary/MenuLabel.swift
@@ -3,7 +3,7 @@ import Library
 import SwiftUI
 
 public struct MenuLabel: View {
-    @EnvironmentObject private var environments: ExtensionEnvirnments
+    @EnvironmentObject private var environments: ExtensionEnvironments
 
     public init() {}
     public var body: some View {
@@ -14,7 +14,7 @@ public struct MenuLabel: View {
     }
 
     private struct MenuLabel0: View {
-        @EnvironmentObject private var environments: ExtensionEnvirnments
+        @EnvironmentObject private var environments: ExtensionEnvironments
         @EnvironmentObject private var extensionProfile: ExtensionProfile
         @StateObject private var commandClient = CommandClient(.status)
 

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-```1
+```

--- a/Tests/ApplicationLibraryTests/NavigationPageTests.swift
+++ b/Tests/ApplicationLibraryTests/NavigationPageTests.swift
@@ -1,5 +1,7 @@
+import NetworkExtension
 import XCTest
 @testable import ApplicationLibrary
+import Library
 
 final class NavigationPageTests: XCTestCase {
     func testPagesForIOSIncludesCommonTabsOnly() {
@@ -24,5 +26,10 @@ final class NavigationPageTests: XCTestCase {
 
     func testGroupsRequireConnectedProfile() {
         XCTAssertFalse(NavigationPage.groups.visible(nil))
+
+        let profile = ExtensionProfile(NEVPNManager())
+        profile.status = .connected
+
+        XCTAssertTrue(NavigationPage.groups.visible(profile))
     }
 }


### PR DESCRIPTION
## Summary
- fix the ExtensionEnvironments typo in the menu label views
- use the stable tag as the SwiftUI identifier for outbound groups
- repair the README license fence and extend the navigation visibility test

## Testing
- Scripts/run-tests.sh *(fails: xcodebuild is required in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d78a845578832380d6e513fce5e09c